### PR TITLE
consistent ConfigMap usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This project demonstrates how to use an [Openshift configmap](https://docs.opens
 The two main attributes that we are going to configure are:
 
  * the log level for the service
- * a greeting value used to configure the application level.
+ * a greeting template used to configure the application.
 
 The service log level can be verified using the Openshift management console (See Application > Pods > Logs).
 The application level configuration on the other hand, will be returned from a REST endpoint.
 
-NOTE: When running the service locally, you won't be able to access the greeting due to the lack of a configmap, and the service returns `n/a`. When running on Openshift however, with a configmap provided, the value of the configmap key `service.greeting` will be returned.
+NOTE: When running the service locally, it will use a default greeting template. When running on Openshift however,
+with a configmap provided, the value of the configmap key `message` will be used as the greeting template.
 
 You can perform this task in three different ways:
 
@@ -60,8 +61,8 @@ mvn clean install
     curl http://localhost:8080/greeting
     ```
 
-  It should return the value `Hello n/a`, because no greeting value was supplied due to the lack of a configmap.
-  But in the next step, running on openshift, we'll supply a configmap with a `service.greeting` property.
+  It should return the value `Hello, World!`, which uses the default greeting template due to the lack of a configmap.
+  But in the next step, running on openshift, we'll supply a configmap with a `message` property.
 
 # OpenShift Online
 
@@ -97,12 +98,12 @@ mvn clean install
     http http://<HOST_PORT_ADDRESS>/greeting    
     ```
 
-    Here the response from the Rest endpoint should
-    contain the greeting defined in the `src/main/fabric8/configmap.yml`:
+    Here the response from the REST endpoint should use the greeting template
+    defined in the `src/main/fabric8/configmap.yml`:
 
     ```
     {
       "id":1,
-      "content":"Hello From ConfigMap"
+      "content":"Hello, World from Kubernetes ConfigMap !"
     }
     ```

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.obsidiantoaster.quickstart</groupId>
-  <artifactId>wildfy-swarm-configmap</artifactId>
+  <artifactId>wildfly-swarm-configmap</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
 

--- a/src/main/fabric8/configmap.yml
+++ b/src/main/fabric8/configmap.yml
@@ -2,8 +2,7 @@ metadata:
   name: ${project.artifactId}
 data:
   project-stages.yml: |-
-    service:
-      greeting: From ConfigMap
+    message: Hello, %s from Kubernetes ConfigMap !
     swarm:
       logging:
         root-logger:

--- a/src/main/java/org/obsidiantoaster/quickstart/service/GreetingController.java
+++ b/src/main/java/org/obsidiantoaster/quickstart/service/GreetingController.java
@@ -35,14 +35,17 @@ public class GreetingController {
     private static final AtomicLong counter = new AtomicLong();
 
     @Inject
-    @ConfigurationValue("service.greeting")
-    Optional<String> greetingValue;
+    @ConfigurationValue("message")
+    Optional<String> message;
 
     @GET
     @Path("/greeting")
     @Produces("application/json")
-    public Greeting greeting() {
-        String suffix = greetingValue.isPresent() ? greetingValue.get(): "n/a";
-        return new Greeting(counter.incrementAndGet(), "Hello "+suffix);
+    public Greeting greeting(@QueryParam(value="name") String name) {
+        if (name == null) {
+            name = "World";
+        }
+        String template = message.orElse("Hello, %s!");
+        return new Greeting(counter.incrementAndGet(), String.format(template, name));
     }
 }

--- a/src/test/java/org/obsidiantoaster/quickstart/JAXRSArquillianTest.java
+++ b/src/test/java/org/obsidiantoaster/quickstart/JAXRSArquillianTest.java
@@ -47,7 +47,7 @@ public class JAXRSArquillianTest {
 
         Response response = target.request(MediaType.APPLICATION_JSON).get();
         Assert.assertEquals(200, response.getStatus());
-        Assert.assertTrue(response.readEntity(String.class).contains("Hello n/a"));
+        Assert.assertTrue(response.readEntity(String.class).contains("Hello, World!"));
     }
 
 }


### PR DESCRIPTION
The ConfigMap usage should be consistent among all quickstarts.
This also makes automated testing much easier.